### PR TITLE
Switch from pyvxi11 to vxi11

### DIFF
--- a/osccap/agilent.py
+++ b/osccap/agilent.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import pyvxi11
+import vxi11
 
 def binary_block(data):
     len_digits = int(data[1])
@@ -24,9 +24,9 @@ def binary_block(data):
     return data[2+len_digits:]
 
 def take_screenshot_png(host, fullscreen=True):
-    dev = pyvxi11.Vxi11(host)
+    dev = vxi11.Instrument("TCPIP::" + host + "::INSTR")
     dev.open()
     dev.write(':DISPLAY:DATA? PNG')
-    img_data = binary_block(dev.read())
+    img_data = binary_block(dev.read_raw())
     dev.close()
     return img_data

--- a/osccap/tektronix.py
+++ b/osccap/tektronix.py
@@ -16,10 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import pyvxi11
+import vxi11
 
 def take_screenshot_png(host, fullscreen=True):
-    dev = pyvxi11.Vxi11(host)
+    dev = vxi11.Instrument("TCPIP::" + host + "::INSTR")
     dev.open()
     dev.io_timeout = 10
     dev.write('*IDN?')


### PR DESCRIPTION
Switch from mwalle/pyvxi11 to python-ivi/python-vxi11

Signed-off-by: Friedemann Lipphardt friedemann.lipphardt@posteo.net